### PR TITLE
Lugg 438 function namespace

### DIFF
--- a/luggage_indicator.module
+++ b/luggage_indicator.module
@@ -40,7 +40,7 @@ function luggage_indicator_preprocess_node(&$variables) {
 // function luggage_indicator_block_view_alter(&$data, $block) {
 //   if($block->delta == 'GiIy4zr9Gu0ZSa0bumw1Y9qIIpIDf1wu' && $data != NULL) {
 //     foreach($data['content']['bundle']['#items'] as &$item) {
-//       $name = strtolower(_get_string_between($item['data'], '>', ' ('));
+//       $name = strtolower(_luggage_indicator_get_string_between($item['data'], '>', ' ('));
 //       if($name == 'basic page') {
 //         $name = 'page';
 //       }
@@ -72,7 +72,7 @@ function _luggage_indicator_get_identifier_element($name, $type, $title) {
   return $str;
 }
 
-function _get_string_between($string, $start, $end){
+function _luggage_indicator_get_string_between($string, $start, $end){
   $string = " ".$string;
   $ini = strpos($string,$start);
   if ($ini == 0) return "";

--- a/luggage_indicator.module
+++ b/luggage_indicator.module
@@ -18,7 +18,7 @@ function luggage_indicator_node_view_alter(&$build) {
       '#markup' => _get_identifier_element(node_type_get_name($build['#node']), 'ct-search', true),
       '#weight' => 0
     );
-    _add_stylesheet();
+    _luggage_indicator_add_stylesheet();
   } else if(arg(0) == 'node') {
     $build['field_content_type_indicator'] = array(
       '#title' => 'Content Type Indicator',
@@ -27,7 +27,7 @@ function luggage_indicator_node_view_alter(&$build) {
         '#markup' => _get_identifier_element(node_type_get_name($build['#node']), 'ct-node', true)
       )
     );
-    _add_stylesheet();
+    _luggage_indicator_add_stylesheet();
   }
 }
 
@@ -46,11 +46,11 @@ function luggage_indicator_preprocess_node(&$variables) {
 //       }
 //       $item['data'] = _get_identifier_element($name, 'block', false) . $item['data'];
 //     }
-//     _add_stylesheet();
+//     _luggage_indicator_add_stylesheet();
 //   }
 // }
 
-function _add_stylesheet() {
+function _luggage_indicator_add_stylesheet() {
   drupal_add_css(drupal_get_path('module', 'luggage_indicator') . '/css/luggage_indicator.css');
 }
 

--- a/luggage_indicator.module
+++ b/luggage_indicator.module
@@ -15,7 +15,7 @@ function luggage_indicator_update_projects_alter(&$projects) {
 function luggage_indicator_node_view_alter(&$build) {
   if(arg(0) == 'search') {
     $build['field_content_type'] = array(
-      '#markup' => _get_identifier_element(node_type_get_name($build['#node']), 'ct-search', true),
+      '#markup' => _luggage_indicator_get_identifier_element(node_type_get_name($build['#node']), 'ct-search', true),
       '#weight' => 0
     );
     _luggage_indicator_add_stylesheet();
@@ -24,7 +24,7 @@ function luggage_indicator_node_view_alter(&$build) {
       '#title' => 'Content Type Indicator',
       '#label_display' => 'none',
       0 => array(
-        '#markup' => _get_identifier_element(node_type_get_name($build['#node']), 'ct-node', true)
+        '#markup' => _luggage_indicator_get_identifier_element(node_type_get_name($build['#node']), 'ct-node', true)
       )
     );
     _luggage_indicator_add_stylesheet();
@@ -44,7 +44,7 @@ function luggage_indicator_preprocess_node(&$variables) {
 //       if($name == 'basic page') {
 //         $name = 'page';
 //       }
-//       $item['data'] = _get_identifier_element($name, 'block', false) . $item['data'];
+//       $item['data'] = _luggage_indicator_get_identifier_element($name, 'block', false) . $item['data'];
 //     }
 //     _luggage_indicator_add_stylesheet();
 //   }
@@ -54,7 +54,7 @@ function _luggage_indicator_add_stylesheet() {
   drupal_add_css(drupal_get_path('module', 'luggage_indicator') . '/css/luggage_indicator.css');
 }
 
-function _get_identifier_element($name, $type, $title) {
+function _luggage_indicator_get_identifier_element($name, $type, $title) {
   $str = '<div class="content-type-indicator ct-' . $name . ' '. $type;
 
   if($title) {


### PR DESCRIPTION
Fixes namespace for `_add_stylesheet()`, `_get_identifier_element()`, `_get_string_between()`.

These functions are not used by any of the modules that luggage installs so there are no side effects unless other custom modules in existing sites use them.
